### PR TITLE
Capitalize "Staff" in head/title.

### DIFF
--- a/site/staff.html
+++ b/site/staff.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Stratus Network - staff
+title: Stratus Network - Staff
 permalink: staff
 ---
 <div class="ui container" style="padding-top:40px;">


### PR DESCRIPTION
Previous title of `Stratus Network - staff` contains a lowercase `staff` whereas the other pages use capitalization. Bugged me and it's an easy fix.