### PR TITLE
Add 'Latest Announcements' to front page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,15 @@ title: Stratus Network - Home
     </div>
 </div>
 <div class="ui container center aligned">
+    <div class="ui icon message">
+        <i class="announcement icon"></i>
+        <div class="content">
+            <b>Latest Announcements: </b>
+            {% for post in site.posts limit:3  %}
+            <a data-tooltip="Created {{post.date | date: "%b %d %Y"}}" data-position="bottom center" style="margin-left:10px;" href="{{post.url}}">{{post.title | truncate: 45}}</a>
+            {% endfor %}
+        </div>
+    </div>
     <section class="main">
         <h1 class="ui header">About us</h1>
         <hr>


### PR DESCRIPTION
Add latest announcements element below jumbotron on the main `index` page.

Displays the three latest announcement posts and date (when hovered).

![image](https://user-images.githubusercontent.com/8608892/28224392-cd63e8be-68c6-11e7-9972-3975be227919.png)



