### PR TITLE
Fix row where no col is provided.

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -9,7 +9,9 @@ layout: default
             <div class="stratus-card-title" style="font-weight: bold">{{page.title}}</div>
             <div class="stratus-card-subtitle">By <img class="avatar image" style="border-radius: .3125em; width: 16px; height: 16px" src="https://crafatar.com/avatars/{{author.id}}?size=16"><b style="color:{{author.color}}">{{page.author}}</b> on <b>{{page.date | date: "%b %d %Y"}}</b></div>
             <hr>
-            <div class="row">{{content}}</div>
+            <div class="row">
+              <div class="col-md-12">{{content}}</div>
+            </div>
         </div>
     </div>
 </section>

--- a/site/announcements.html
+++ b/site/announcements.html
@@ -11,14 +11,17 @@ permalink: announcements
 <div class="row stratus-card">
   <div class="stratus-card-container">
     <div class="row">
-      <div class="stratus-card-title pull-left">{{post.title}}<small style="padding-left:5px;">By <img class="ui avatar image" style="border-radius:.3125em;width:16px;height:16px;"src="https://crafatar.com/avatars/{{author.id}}?size=16"></img><b style="color:{{author.color}}">{{post.author}}</b></small></div>
-      <div class="stratus-card-date pull-right">{{post.date | date: "%b %d %Y"}}</div>
+      <div class="col-md-12">
+        <div class="stratus-card-title pull-left">{{post.title}}<small style="padding-left:5px;">By <img class="ui avatar image" style="border-radius:.3125em;width:16px;height:16px;"src="https://crafatar.com/avatars/{{author.id}}?size=16"></img><b style="color:{{author.color}}">{{post.author}}</b></small></div>
+        <div class="stratus-card-date pull-right">{{post.date | date: "%b %d %Y"}}</div>
+        <br>
+        <hr>
+        <div class="well">{{ post.content | strip_html | truncatewords: 50 }}</div>
+        <hr>
+        <a class="btn btn-primary pull-right" href="{{post.url}}">Keep Reading</a>
+      </div>
     </div>
-    <hr>
-    <div class="well">{{ post.content | strip_html | truncatewords: 50 }}</div>
-    <hr>
-    <a class="btn btn-primary stratus-card-link pull-right" href="{{post.url}}">Keep Reading</a>
-    </div>
+  </div>
 </div>
 {% endfor %}
 <br>


### PR DESCRIPTION
The `row` element is used however contains no `col` of any type, meaning the content has a -15px margin which messes with the alignment.

In many cases this isn't an issue as the content isn't aligned other objects. 
The two places where this is an issue is the announcements index and page.


![wrong-1](https://user-images.githubusercontent.com/8608892/28250783-d1e54c86-6a68-11e7-8619-c87375037520.png)



![wrong-2](https://user-images.githubusercontent.com/8608892/28250784-d43fad82-6a68-11e7-867b-24f3c03a730d.png)
